### PR TITLE
Specification tweaks

### DIFF
--- a/draft-looker-jwm.txt
+++ b/draft-looker-jwm.txt
@@ -1091,7 +1091,7 @@ Internet-Draft                     jwm                     December 2019
    Kyle Den Hartog
    Daniel Hardman
    Troy Ronda
-   Troy Ronda
+   George Aristy
 
 12.  Normative References
 

--- a/draft-looker-jwm.txt
+++ b/draft-looker-jwm.txt
@@ -889,7 +889,7 @@ Internet-Draft                     jwm                     December 2019
    [RFC7518], only ECDSA using the P-256 curve and SHA-256 hash
    algorithm ("ES256") MUST be implemented by conforming JWM
    implementations.  It is RECOMMENDED that implementations also support
-   ECDSA using the P-256 curve and SHA-256 hash algorithm ("ES256") MUST
+   ECDSA using the P-521 curve and the SHA-512 hash algorithm ("ES512")
 
 
 
@@ -898,8 +898,8 @@ Looker                    Expires June 23, 2020                [Page 16]
 Internet-Draft                     jwm                     December 2019
 
 
-   be implemented Ed25519 curve and SHA-512 hash algorithm.  Support for
-   other algorithms and key sizes is OPTIONAL.
+   and EdDSA using the Ed25519 curve and SHA-512 hash algorithm.
+   Support for other algorithms and key sizes is OPTIONAL.
 
    Support for encrypted JWMs using JWE is also REQUIRED.  Of the
    encryption algorithms specified in [RFC7518], using Elliptic Curve

--- a/draft-looker-jwm.txt
+++ b/draft-looker-jwm.txt
@@ -741,8 +741,7 @@ Internet-Draft                     jwm                     December 2019
        Parameters.  The JWM MUST conform to either the JWS [RFC7515] or
        JWE [RFC7516] specification.  Note that whitespace is explicitly
        allowed in the representation and no canonicalization need be
-       performed before encoding.  THE JOSE "typ" header must be set to
-       "JWM".
+       performed before encoding.
 
    4.  Depending upon whether the JWM is a JWS or JWE, there are two
        cases:
@@ -774,6 +773,7 @@ Internet-Draft                     jwm                     December 2019
        in the new JOSE Header created in that step.
 
    2.  Otherwise, let the resulting JWM be the JWS or JWE.
+
 
 
 
@@ -889,7 +889,7 @@ Internet-Draft                     jwm                     December 2019
    [RFC7518], only ECDSA using the P-256 curve and SHA-256 hash
    algorithm ("ES256") MUST be implemented by conforming JWM
    implementations.  It is RECOMMENDED that implementations also support
-   ECDSA using the P-521 curve and the SHA-512 hash algorithm ("ES512")
+   ECDSA using the P-256 curve and SHA-256 hash algorithm ("ES256") MUST
 
 
 
@@ -898,17 +898,19 @@ Looker                    Expires June 23, 2020                [Page 16]
 Internet-Draft                     jwm                     December 2019
 
 
-   and EdDSA using the Ed25519 curve and SHA-512 hash algorithm.
-   Support for other algorithms and key sizes is OPTIONAL.
+   be implemented Ed25519 curve and SHA-512 hash algorithm.  Support for
+   other algorithms and key sizes is OPTIONAL.
 
    Support for encrypted JWMs using JWE is also REQUIRED.  Of the
    encryption algorithms specified in [RFC7518], using Elliptic Curve
-   Diffie-Hellman Ephemeral Static (ECDH-ES) to agree upon a key and
-   using this key to to perform key wrapping of a Content Encryption Key
-   ("ECDH-ES+A128KW" and "ECDH-ES+A256KW") MUST be supported.  With
-   regards to content encryption, AES in Galois/Counter Mode (GCM) with
-   128-bit and 256-bit keys ("A128GCM" and "A256GCM") MUST also be
-   supported.
+   Diffie-Hellman Ephemeral Static (ECDH-ES) with the P-256 curve to
+   agree upon a key and using this key to to perform key wrapping of a
+   Content Encryption Key ("ECDH-ES+A128KW" and "ECDH-ES+A256KW") MUST
+   be supported.  With regards to content encryption, AES in Galois/
+   Counter Mode (GCM) with 128-bit and 256-bit keys ("A128GCM" and
+   "A256GCM") MUST also be supported.  It is RECOMMENDED that
+   implementations also support ECDH-ES and key wrapping variants using
+   the X25519 curve also.
 
    Usage of the "none" algorithm identifier in a JWM as defined in the
    JOSE Web Algorithms section 3.6 [RFC7518] MUST be considered invalid.
@@ -923,7 +925,7 @@ Internet-Draft                     jwm                     December 2019
 
    The name requested (e.g., "type").  Because a core goal of this
    specification is for the resulting representations to be compact, it
-   is RECOMMENDED that the name be short - that is, not to exceed 8
+   is RECOMMENDED that the name be short - that is, not to exceed 15
    characters without a compelling reason to do so.  This name is case
    sensitive.  Names may not match other registered names in a case-
    insensitive manner unless the Designated Experts state that there is
@@ -943,8 +945,6 @@ Internet-Draft                     jwm                     December 2019
 
    Reference to the document or documents that specify the parameter,
    preferably including URIs that can be used to retrieve copies of the
-   documents.  An indication of the relevant sections may also be
-   included but is not required.
 
 
 
@@ -953,6 +953,9 @@ Looker                    Expires June 23, 2020                [Page 17]
 
 Internet-Draft                     jwm                     December 2019
 
+
+   documents.  An indication of the relevant sections may also be
+   included but is not required.
 
 7.1.5.  Initial Registry Contents
 
@@ -999,9 +1002,6 @@ Internet-Draft                     jwm                     December 2019
    o Attribute Name: "reply_url"
    o Attribute Description: Message Reply URL
    o Change Controller:
-   o Specification Document(s):
-
-   o Attribute Name: "reply_to"
 
 
 
@@ -1010,6 +1010,9 @@ Looker                    Expires June 23, 2020                [Page 18]
 Internet-Draft                     jwm                     December 2019
 
 
+   o Specification Document(s):
+
+   o Attribute Name: "reply_to"
    o Attribute Description: Message Reply To
    o Change Controller:
    o Specification Document(s):
@@ -1055,9 +1058,6 @@ Internet-Draft                     jwm                     December 2019
    Note that potential concerns about security issues related to the
    order of signing and encryption operations are already addressed by
    the underlying JWS and JWE specifications; in particular, because JWE
-   only supports the use of authenticated encryption algorithms,
-   cryptographic concerns about the potential need to sign after
-
 
 
 
@@ -1066,6 +1066,8 @@ Looker                    Expires June 23, 2020                [Page 19]
 Internet-Draft                     jwm                     December 2019
 
 
+   only supports the use of authenticated encryption algorithms,
+   cryptographic concerns about the potential need to sign after
    encryption that apply in many contexts do not apply to this
    specification.
 
@@ -1083,11 +1085,13 @@ Internet-Draft                     jwm                     December 2019
 
 11.  Acknowledgements
 
-   The authors of this specification would like to acknowledge the
-   following individuals for the significant contribution of ideas and
-   time spent reviewing this document:
+   The authors of this draft would like to acknowledge the following
+   individuals for the significant contribution of ideas and time spent
+   reviewing this document:
    Kyle Den Hartog
    Daniel Hardman
+   Troy Ronda
+   Troy Ronda
 
 12.  Normative References
 
@@ -1110,10 +1114,6 @@ Internet-Draft                     jwm                     December 2019
               Interchange Format", RFC 7159, DOI 10.17487/RFC7159, March
               2014, <https://www.rfc-editor.org/info/rfc7159>.
 
-   [RFC7515]  Jones, M., Bradley, J., and N. Sakimura, "JSON Web
-              Signature (JWS)", RFC 7515, DOI 10.17487/RFC7515, May
-              2015, <https://www.rfc-editor.org/info/rfc7515>.
-
 
 
 
@@ -1121,6 +1121,10 @@ Looker                    Expires June 23, 2020                [Page 20]
 
 Internet-Draft                     jwm                     December 2019
 
+
+   [RFC7515]  Jones, M., Bradley, J., and N. Sakimura, "JSON Web
+              Signature (JWS)", RFC 7515, DOI 10.17487/RFC7515, May
+              2015, <https://www.rfc-editor.org/info/rfc7515>.
 
    [RFC7516]  Jones, M. and J. Hildebrand, "JSON Web Encryption (JWE)",
               RFC 7516, DOI 10.17487/RFC7516, May 2015,
@@ -1144,10 +1148,6 @@ Author's Address
    Mattr
 
    Email: tobias.looker@mattr.global
-
-
-
-
 
 
 

--- a/draft-looker-jwm.xml
+++ b/draft-looker-jwm.xml
@@ -537,7 +537,7 @@
 
       <t>Support for digitally signed JWMs using JWS is REQUIRED. Of the signature and 
       MAC algorithms specified in JSON Web Algorithms <xref target="RFC7518"/>, only 
-      ECDSA using the Ed25519 curve and SHA-256 hash algorithm ("ES256") MUST be implemented 
+      ECDSA using the Ed25519 curve and SHA-256 hash algorithm MUST be implemented 
       by conforming JWM implementations. It is RECOMMENDED that implementations also support
       ECDSA using the P-521 curve and the SHA-512 hash algorithm ("ES512") and EdDSA using the 
       P-256 curve and SHA-512 hash algorithm ("ES256"). Support for other algorithms and key sizes is 

--- a/draft-looker-jwm.xml
+++ b/draft-looker-jwm.xml
@@ -557,7 +557,7 @@
       <section anchor="registration-template" title="Registration Template">
         <section anchor="attribute-name-registration-template" title="Attribute Name:">
           <t>The name requested (e.g., "type").  Because a core goal of this specification is for the resulting representations to be compact,
-          it is RECOMMENDED that the name be short &#8211; that is, not to exceed 8 characters without a compelling reason to do so.  This name 
+          it is RECOMMENDED that the name be short &#8211; that is, not to exceed 15 characters without a compelling reason to do so.  This name 
           is case sensitive.  Names may not match other registered names in a case-insensitive manner unless the Designated Experts state that 
           there is a compelling reason to allow an exception.</t>
         </section>

--- a/draft-looker-jwm.xml
+++ b/draft-looker-jwm.xml
@@ -539,7 +539,7 @@
       MAC algorithms specified in JSON Web Algorithms <xref target="RFC7518"/>, only 
       ECDSA using the P-256 curve and SHA-256 hash algorithm ("ES256") MUST be implemented 
       by conforming JWM implementations. It is RECOMMENDED that implementations also support
-      ECDSA using the P-256 curve and SHA-256 hash algorithm ("ES256") MUST be implemented
+      ECDSA using the P-521 curve and the SHA-512 hash algorithm ("ES512") and EdDSA using the
       Ed25519 curve and SHA-512 hash algorithm. Support for other algorithms and key sizes is 
       OPTIONAL.</t>
 

--- a/draft-looker-jwm.xml
+++ b/draft-looker-jwm.xml
@@ -537,10 +537,10 @@
 
       <t>Support for digitally signed JWMs using JWS is REQUIRED. Of the signature and 
       MAC algorithms specified in JSON Web Algorithms <xref target="RFC7518"/>, only 
-      ECDSA using the Ed25519 curve and SHA-256 hash algorithm MUST be implemented 
+      ECDSA using the Ed25519 curve and SHA-512 hash algorithm MUST be implemented 
       by conforming JWM implementations. It is RECOMMENDED that implementations also support
       ECDSA using the P-521 curve and the SHA-512 hash algorithm ("ES512") and EdDSA using the 
-      P-256 curve and SHA-512 hash algorithm ("ES256"). Support for other algorithms and key sizes is 
+      P-256 curve and SHA-256 hash algorithm ("ES256"). Support for other algorithms and key sizes is 
       OPTIONAL.</t>
 
       <t>Support for encrypted JWMs using JWE is also REQUIRED. Of the encryption algorithms

--- a/draft-looker-jwm.xml
+++ b/draft-looker-jwm.xml
@@ -537,20 +537,20 @@
 
       <t>Support for digitally signed JWMs using JWS is REQUIRED. Of the signature and 
       MAC algorithms specified in JSON Web Algorithms <xref target="RFC7518"/>, only 
-      ECDSA using the Ed25519 curve and SHA-512 hash algorithm MUST be implemented 
+      ECDSA using the P-256 curve and SHA-256 hash algorithm ("ES256") MUST be implemented 
       by conforming JWM implementations. It is RECOMMENDED that implementations also support
-      ECDSA using the P-521 curve and the SHA-512 hash algorithm ("ES512") and EdDSA using the 
-      P-256 curve and SHA-256 hash algorithm ("ES256"). Support for other algorithms and key sizes is 
+      ECDSA using the P-256 curve and SHA-256 hash algorithm ("ES256") MUST be implemented
+      Ed25519 curve and SHA-512 hash algorithm. Support for other algorithms and key sizes is 
       OPTIONAL.</t>
 
       <t>Support for encrypted JWMs using JWE is also REQUIRED. Of the encryption algorithms
       specified in <xref target="RFC7518"/>, using Elliptic Curve Diffie-Hellman Ephemeral 
-      Static (ECDH-ES) with the X25519 curve to agree upon a key and using 
+      Static (ECDH-ES) with the P-256 curve to agree upon a key and using 
       this key to to perform key wrapping of a Content Encryption Key ("ECDH-ES+A128KW" and 
       "ECDH-ES+A256KW") MUST be supported. With regards to content encryption, AES in 
       Galois/Counter Mode (GCM) with 128-bit and 256-bit keys ("A128GCM" and "A256GCM") 
       MUST also be supported. It is RECOMMENDED that implementations also support ECDH-ES and
-      key wrapping variants using the P-256 curve also.</t>
+      key wrapping variants using the X25519 curve also.</t>
 
       <t>Usage of the "none" algorithm identifier in a JWM as defined in the JOSE Web Algorithms section 3.6 
       <xref target="RFC7518"/> MUST be considered invalid.</t>
@@ -695,11 +695,13 @@
     </section>
 
     <section anchor="acknowledgements" title="Acknowledgements">
-    <t>The authors of this specification would like to acknowledge the 
+    <t>The authors of this draft would like to acknowledge the 
     following individuals for the significant contribution of ideas and 
     time spent reviewing this document:<vspace/>
     Kyle Den Hartog<vspace/>
-    Daniel Hardman<vspace/></t>
+    Daniel Hardman<vspace/>
+    Troy Ronda<vspace/>
+    Troy Ronda<vspace/></t>
     </section>
   </middle>
 

--- a/draft-looker-jwm.xml
+++ b/draft-looker-jwm.xml
@@ -429,9 +429,12 @@
         are no dependencies between the inputs and outputs of the steps.</t>
 
         <t><list style="numbers">
-          <t>Create a JWM Attribute Set containing the desired attributes. Note that whitespace is explicitly allowed in the representation and no canonicalization need be performed before encoding.</t>
+          <t>Create a JWM Attribute Set containing the desired attributes. Note that whitespace is explicitly allowed in the 
+          representation and no canonicalization need be performed before encoding.</t>
           <t>Let the Message be the octets of the UTF-8 representation of the JWM Attributes Set.</t>
-          <t>Create a JOSE Header containing the desired set of Header Parameters. The JWM MUST conform to either the JWS <xref target="RFC7515"/> or JWE <xref target="RFC7516"/> specification. Note that whitespace is explicitly allowed in the representation and no canonicalization need be performed before encoding. THE JOSE "typ" header must be set to "JWM".</t>
+          <t>Create a JOSE Header containing the desired set of Header Parameters. The JWM MUST conform to either the JWS 
+          <xref target="RFC7515"/> or JWE <xref target="RFC7516"/> specification. Note that whitespace is explicitly allowed 
+          in the representation and no canonicalization need be performed before encoding.</t>
           <t>Depending upon whether the JWM is a JWS or JWE, there are two cases:</t>
         </list></t>
 
@@ -534,18 +537,20 @@
 
       <t>Support for digitally signed JWMs using JWS is REQUIRED. Of the signature and 
       MAC algorithms specified in JSON Web Algorithms <xref target="RFC7518"/>, only 
-      ECDSA using the P-256 curve and SHA-256 hash algorithm ("ES256") MUST be implemented 
+      ECDSA using the Ed25519 curve and SHA-256 hash algorithm ("ES256") MUST be implemented 
       by conforming JWM implementations. It is RECOMMENDED that implementations also support
       ECDSA using the P-521 curve and the SHA-512 hash algorithm ("ES512") and EdDSA using the 
-      Ed25519 curve and SHA-512 hash algorithm. Support for other algorithms and key sizes is 
+      P-256 curve and SHA-512 hash algorithm ("ES256"). Support for other algorithms and key sizes is 
       OPTIONAL.</t>
 
       <t>Support for encrypted JWMs using JWE is also REQUIRED. Of the encryption algorithms
       specified in <xref target="RFC7518"/>, using Elliptic Curve Diffie-Hellman Ephemeral 
-      Static (ECDH-ES) to agree upon a key and using this key to to perform key wrapping
-      of a Content Encryption Key ("ECDH-ES+A128KW" and "ECDH-ES+A256KW") MUST be supported. 
-      With regards to content encryption, AES in Galois/Counter Mode (GCM) with 128-bit and 256-bit
-      keys ("A128GCM" and "A256GCM") MUST also be supported.</t>
+      Static (ECDH-ES) with the X25519 curve to agree upon a key and using 
+      this key to to perform key wrapping of a Content Encryption Key ("ECDH-ES+A128KW" and 
+      "ECDH-ES+A256KW") MUST be supported. With regards to content encryption, AES in 
+      Galois/Counter Mode (GCM) with 128-bit and 256-bit keys ("A128GCM" and "A256GCM") 
+      MUST also be supported. It is RECOMMENDED that implementations also support ECDH-ES and
+      key wrapping variants using the P-256 curve also.</t>
 
       <t>Usage of the "none" algorithm identifier in a JWM as defined in the JOSE Web Algorithms section 3.6 
       <xref target="RFC7518"/> MUST be considered invalid.</t>

--- a/draft-looker-jwm.xml
+++ b/draft-looker-jwm.xml
@@ -701,7 +701,7 @@
     Kyle Den Hartog<vspace/>
     Daniel Hardman<vspace/>
     Troy Ronda<vspace/>
-    Troy Ronda<vspace/></t>
+    George Aristy<vspace/></t>
     </section>
   </middle>
 


### PR DESCRIPTION
This PR addresses the following.

- Relaxes the condition in the "Creating a JWM section" that required the JOSE header to feature a "typ" field equal to "JWM"
- Changes the crypto requirement section in the following way
    - Require P-256 as ECC curve for ECDSA, ED25519 curve support is optional.
    - Require  P-256 as ECC curve for ECDH-ES, X25519 curve support is optional.
- Bump the recommended character limit for JWM attributes from 8 to 15.

Fixes #38, #40, #41 

@troyronda @llorllale 